### PR TITLE
Allow GPU acceralation

### DIFF
--- a/com.github.ryonakano.pinit.yml
+++ b/com.github.ryonakano.pinit.yml
@@ -8,6 +8,8 @@ finish-args:
   - '--socket=wayland'
   - '--socket=fallback-x11'
   - '--filesystem=home'
+  # For drawing icons
+  - '--device=dri'
   # needed for perfers-color-scheme
   - '--system-talk-name=org.freedesktop.Accounts'
 modules:


### PR DESCRIPTION
Fixes these error messages are shown on launch:

```
libGL error: MESA-LOADER: failed to retrieve device information
libGL error: Version 4 or later of flush extension not found
libGL error: failed to load driver: i915
libGL error: failed to open /dev/dri/card0: No such file or directory
libGL error: failed to load driver: iris
```
