### PR TITLE
Flatpak: Revoke access to AccountsService

### DIFF
--- a/com.github.ryonakano.pinit.yml
+++ b/com.github.ryonakano.pinit.yml
@@ -10,8 +10,6 @@ finish-args:
   - '--filesystem=home'
   # For drawing icons
   - '--device=dri'
-  # needed for perfers-color-scheme
-  - '--system-talk-name=org.freedesktop.Accounts'
 modules:
   - name: pinit
     buildsystem: meson


### PR DESCRIPTION
We don't need this since Flatpak Platform 6.0.2
