### PR TITLE
Revert "Revert "Flatpak: Only allow access to the desktop files dir" (#65)"

### DIFF
--- a/com.github.ryonakano.pinit.yml
+++ b/com.github.ryonakano.pinit.yml
@@ -7,7 +7,7 @@ finish-args:
   - '--share=ipc'
   - '--socket=wayland'
   - '--socket=fallback-x11'
-  - '--filesystem=home'
+  - '--filesystem=~/.local/share/applications'
   # For drawing icons
   - '--device=dri'
 modules:


### PR DESCRIPTION
We can show the path in the home dir in this way but the path to else (e.g. on another disk) are still shown in the "/run" dir.
We should seek for another way to show the path correctly instead of giving unnecessary permission.
