### PR TITLE
DesktopFilesOperator: Don't overwrite the current file mode

### DIFF
--- a/src/Backend/DesktopFileOperator.vala
+++ b/src/Backend/DesktopFileOperator.vala
@@ -112,9 +112,6 @@ public class DesktopFileOperator : GLib.Object {
      * Write the content of `desktop_file@ into the desktop file at `desktop_file.file_name` through KeyFile object.
      */
     public void write_to_file (DesktopFile desktop_file) {
-        // Add exec permission to the given exec file
-        Posix.chmod (desktop_file.exec_file, 0700);
-
         var keyfile = new KeyFile ();
 
         keyfile.set_locale_string (
@@ -270,6 +267,24 @@ public class DesktopFileOperator : GLib.Object {
         );
 
         return desktop_file;
+    }
+
+    /*
+     * Add executable permission to the given file at `path`.
+     */
+    public void add_exec_permission (string path) {
+        Posix.Stat sbuf;
+
+        int ret_stat = Posix.stat (path, out sbuf);
+        if (ret_stat != 0) {
+            warning ("Failed to get the current mode of the file specified as a exec file.");
+            return;
+        }
+
+        int ret_chmod = Posix.chmod (path, sbuf.st_mode & 0100);
+        if (ret_chmod != 0) {
+            warning ("Failed to give exec permission to the file specified as a exec file.");
+        }
     }
 
     /*

--- a/src/Backend/DesktopFileOperator.vala
+++ b/src/Backend/DesktopFileOperator.vala
@@ -277,13 +277,15 @@ public class DesktopFileOperator : GLib.Object {
 
         int ret_stat = Posix.stat (path, out sbuf);
         if (ret_stat != 0) {
-            warning ("Failed to get the current mode of the file specified as a exec file.");
+            warning ("Failed to get the current mode of '%s': %s",
+                    path, Posix.strerror (Posix.errno));
             return;
         }
 
-        int ret_chmod = Posix.chmod (path, sbuf.st_mode & 0100);
+        int ret_chmod = Posix.chmod (path, (sbuf.st_mode & 0777) | 0100);
         if (ret_chmod != 0) {
-            warning ("Failed to give exec permission to the file specified as a exec file.");
+            warning ("Failed to give exec permission to '%s': %s",
+                    path, Posix.strerror (Posix.errno));
         }
     }
 

--- a/src/Views/EditView.vala
+++ b/src/Views/EditView.vala
@@ -452,7 +452,7 @@ public class EditView : Gtk.Box {
             is_backup
         );
         DesktopFileOperator.get_default ().write_to_file (desktop_file);
-        DesktopFileOperator.get_default ().add_exec_permission (desktop_file.file_name);
+        DesktopFileOperator.get_default ().add_exec_permission (desktop_file.exec_file);
     }
 
     /*

--- a/src/Views/EditView.vala
+++ b/src/Views/EditView.vala
@@ -452,6 +452,7 @@ public class EditView : Gtk.Box {
             is_backup
         );
         DesktopFileOperator.get_default ().write_to_file (desktop_file);
+        DesktopFileOperator.get_default ().add_exec_permission (desktop_file.file_name);
     }
 
     /*


### PR DESCRIPTION
Changing the file mode to `700` can remove any permission to other users and it can be a problem when the given exec file is shared at e.g. on another disk, etc. We should just give exec permission to the file for the current user and keep the current file mode as same as possible.