### PR TITLE
Metainfo: Rename and improve

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -17,8 +17,8 @@ i18n.merge_file(
 )
 
 i18n.merge_file(
-    input: 'pinit.appdata.xml.in',
-    output: meson.project_name() + '.appdata.xml',
+    input: 'pinit.metainfo.xml.in',
+    output: meson.project_name() + '.metainfo.xml',
     po_dir: meson.project_source_root() / 'po' / 'extra',
     install: true,
     install_dir: get_option('datadir') / 'metainfo'

--- a/data/pinit.metadata.xml.in
+++ b/data/pinit.metadata.xml.in
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2021-2022 Ryo Nakano -->
-<component type="desktop">
+<component type="desktop-application">
   <id>com.github.ryonakano.pinit</id>
   <launchable type="desktop-id">com.github.ryonakano.pinit.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
+
   <name>Pin It!</name>
   <summary>Create the shortcut to your favorite portable apps into your app launcher</summary>
   <description>
@@ -21,26 +22,48 @@
       <li>Automatically save everything―your data in editing, last open view, and preferences</li>
     </ul>
   </description>
+
   <screenshots>
     <screenshot type="default">
       <caption>Files view in the light mode</caption>
+      <!-- TODO: Use fixed screenshots path when releasing 2.0.0 -->
       <image>https://raw.githubusercontent.com/ryonakano/pinit/main/data/screenshots/pantheon/screenshot-files-view-light.png</image>
     </screenshot>
+
     <screenshot>
       <caption>Edit view in the light mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/main/data/screenshots/pantheon/screenshot-edit-view-light.png</image>
     </screenshot>
+
     <screenshot>
       <caption>Files view in the dark mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/main/data/screenshots/pantheon/screenshot-files-view-dark.png</image>
     </screenshot>
+
     <screenshot>
       <caption>Edit view in the dark mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/main/data/screenshots/pantheon/screenshot-edit-view-dark.png</image>
     </screenshot>
   </screenshots>
 
+  <branding>
+    <color type="primary">#28bca3</color>
+    <color type="primary" schema_preference="light">#89ffdd</color>
+    <color type="primary" schema_preference="dark">#007367</color>
+  </branding>
+
   <content_rating type="oars-1.1" />
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </supports>
+
+  <developer_name>Ryo Nakano</developer_name>
+  <url type="homepage">https://github.com/ryonakano/pinit</url>
+  <url type="bugtracker">https://github.com/ryonakano/pinit/issues</url>
+  <url type="help">https://github.com/ryonakano/pinit/discussions</url>
+  <url type="translate">https://hosted.weblate.org/projects/rosp</url>
 
   <releases>
     <release version="2.0.0" date="2022-08-07" urgency="high">
@@ -67,6 +90,7 @@
         </ul>
       </description>
     </release>
+
     <release version="1.4.1" date="2022-04-09" urgency="low">
       <description>
         <ul>
@@ -78,6 +102,7 @@
         </ul>
       </description>
     </release>
+
     <release version="1.4.0" date="2022-04-04" urgency="medium">
       <description>
         <ul>
@@ -94,6 +119,7 @@
         </ul>
       </description>
     </release>
+
     <release version="1.3.0" date="2021-12-17" urgency="medium">
       <description>
         <ul>
@@ -110,6 +136,7 @@
         </ul>
       </description>
     </release>
+
     <release version="1.2.2" date="2021-12-03" urgency="medium">
       <description>
         <ul>
@@ -123,6 +150,7 @@
         </ul>
       </description>
     </release>
+
     <release version="1.2.1" date="2021-10-19" urgency="medium">
       <description>
         <ul>
@@ -136,6 +164,7 @@
         </ul>
       </description>
     </release>
+
     <release version="1.2.0" date="2021-10-13" urgency="medium">
       <description>
         <ul>
@@ -148,6 +177,7 @@
         </ul>
       </description>
     </release>
+
     <release version="1.1.0" date="2021-10-12" urgency="low">
       <description>
         <ul>
@@ -161,6 +191,7 @@
         </ul>
       </description>
     </release>
+
     <release version="1.0.0" date="2021-10-07" urgency="medium">
       <description>
         <ul>
@@ -177,6 +208,7 @@
         </ul>
       </description>
     </release>
+
     <release version="0.1.0" date="2021-10-01" urgency="medium">
       <description>
         <ul>
@@ -186,14 +218,4 @@
     </release>
   </releases>
 
-  <developer_name>Ryo Nakano</developer_name>
-  <url type="homepage">https://github.com/ryonakano/pinit</url>
-  <url type="bugtracker">https://github.com/ryonakano/pinit/issues</url>
-  <url type="help">https://github.com/ryonakano/pinit/discussions</url>
-  <url type="translate">https://hosted.weblate.org/projects/rosp</url>
-  
-  <custom>
-    <value key="x-appcenter-color-primary">#28bca3</value>
-    <value key="x-appcenter-color-primary-text">#1a1a1a</value>
-  </custom>
 </component>

--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,2 +1,2 @@
-data/pinit.appdata.xml.in
+data/pinit.metainfo.xml.in
 data/pinit.desktop.in


### PR DESCRIPTION
Same with https://github.com/ryonakano/konbucase/pull/96

- Rename to `.metainfo.xml.in` which recommended by fd.o
- Use "desktop-application" instead of deprecated "desktop" for `component` tag
- Add caption to screenshots
- Use fd.o standardized `brand` tag instead of `custom` tag by elementary
- Add `supports` tag

References:

- https://freedesktop.org/software/appstream/docs/sect-Metadata-Application.html
- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html
