### PR TITLE
Fix navigate back shows empty window

### DIFF
--- a/data/pinit.metainfo.xml.in
+++ b/data/pinit.metainfo.xml.in
@@ -76,6 +76,7 @@
           <li>English grammatical changes (thanks to @BraidenPsiuk)</li>
           <li>EditView: Make keys that is not required by the freedesktop.org specification optional</li>
           <li>CategoryChooser: Improve layout management</li>
+          <li>Fix navigate back shows empty window</li>
           <li>Update Flatpak runtime version</li>
           <li>Update translations</li>
         </ul>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -35,7 +35,6 @@ public class MainWindow : Adw.ApplicationWindow {
             set_header_buttons_form ();
         });
         leaflet.append (files_view);
-        leaflet.append (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         leaflet.append (edit_view);
 
         var overlay = new Adw.ToastOverlay () {
@@ -106,7 +105,7 @@ public class MainWindow : Adw.ApplicationWindow {
 
     private void set_header_buttons_form () {
         edit_view.set_header_buttons_form (leaflet.folded);
-        files_view.headerbar.show_end_title_buttons = leaflet.folded;
+        files_view.set_header_buttons_form (leaflet.folded);
     }
 
     public void show_files_view () {

--- a/src/Views/FilesView.vala
+++ b/src/Views/FilesView.vala
@@ -11,6 +11,7 @@ public class FilesView : Gtk.Box {
 
     private Gtk.ListBox files_list;
     private Gtk.Stack stack;
+    private Gtk.Separator separator;
 
     public FilesView (MainWindow window) {
         Object (window: window);
@@ -72,15 +73,32 @@ public class FilesView : Gtk.Box {
         stack.add_named (files_list_page, "files_list_page");
         stack.add_named (no_files_page, "no_files_page");
 
+        separator = new Gtk.Separator (Gtk.Orientation.VERTICAL);
+
+        var box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        box.append (stack);
+        box.append (separator);
+
         orientation = Gtk.Orientation.VERTICAL;
         append (headerbar);
-        append (stack);
+        append (box);
 
         update_list ();
 
         create_button.clicked.connect (() => {
             window.show_edit_view (DesktopFileOperator.get_default ().create_new ());
         });
+    }
+
+    /*
+     * Set the buttons visibility and appearance depending on whether the leaflet is folded
+     */
+    public void set_header_buttons_form (bool folded) {
+        // We can use the end title buttons in the edit view when the leaflet is folded
+        headerbar.show_end_title_buttons = folded;
+
+        // Show the separator between views only when the leaflet is folded
+        separator.visible = !folded;
     }
 
     /*

--- a/src/Views/FilesView.vala
+++ b/src/Views/FilesView.vala
@@ -7,8 +7,8 @@ public class FilesView : Gtk.Box {
     public signal void file_deleted ();
 
     public MainWindow window { private get; construct; }
-    public Adw.HeaderBar headerbar { get; private set; }
 
+    private Adw.HeaderBar headerbar;
     private Gtk.ListBox files_list;
     private Gtk.Stack stack;
     private Gtk.Separator separator;


### PR DESCRIPTION
Because it navigates back to the separator

![Peek 2023-10-01 09-34](https://github.com/ryonakano/pinit/assets/26003928/9cd699f1-70c0-4dbb-aa63-53815a85c12c)
