### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/pinit.metainfo.xml.in
+++ b/data/pinit.metainfo.xml.in
@@ -67,7 +67,7 @@
 
   <releases>
     <release version="2.0.2" date="2023-10-01" urgency="low">
-      <description>
+      <description translatable="no">
         <p>
           The release for celebrating the 2nd anniversary of the app!
         </p>
@@ -84,7 +84,7 @@
     </release>
 
     <release version="2.0.1" date="2023-04-15" urgency="low">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Update Flatpak runtime version</li>
           <li>Update translations</li>
@@ -93,7 +93,7 @@
     </release>
 
     <release version="2.0.0" date="2023-01-10" urgency="high">
-      <description>
+      <description translatable="no">
         <p>
           The biggest and greatest updates come to "Pin It!":
         </p>
@@ -118,7 +118,7 @@
     </release>
 
     <release version="1.4.1" date="2022-04-09" urgency="low">
-      <description>
+      <description translatable="no">
         <ul>
           <li>AppData: Fix release year</li>
         </ul>
@@ -130,7 +130,7 @@
     </release>
 
     <release version="1.4.0" date="2022-04-04" urgency="medium">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Check desktop environment on runtime</li>
           <li>Lessen scope of file access</li>
@@ -147,7 +147,7 @@
     </release>
 
     <release version="1.3.0" date="2021-12-17" urgency="medium">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fix build error on other distros</li>
           <li>FilesView: Properly center the dialog against the app window</li>
@@ -164,7 +164,7 @@
     </release>
 
     <release version="1.2.2" date="2021-12-03" urgency="medium">
-      <description>
+      <description translatable="no">
         <ul>
           <li>FilesView: Ellipsize if label texts are too long</li>
           <li>Tell accepted file formats in FileChooser</li>
@@ -178,7 +178,7 @@
     </release>
 
     <release version="1.2.1" date="2021-10-19" urgency="medium">
-      <description>
+      <description translatable="no">
         <ul>
           <li>EditView: Focus on file name entry by default</li>
           <li>FilesView: Make scrollable and fix the window get bigger if many entries</li>
@@ -192,7 +192,7 @@
     </release>
 
     <release version="1.2.0" date="2021-10-13" urgency="medium">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Improved support for other desktop environments</li>
           <li>Add execution permission on clicking the "Pin It!" button</li>
@@ -205,7 +205,7 @@
     </release>
 
     <release version="1.1.0" date="2021-10-12" urgency="low">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Add CategoryChooser</li>
           <li>Support Alt+Home to show welcome</li>
@@ -219,7 +219,7 @@
     </release>
 
     <release version="1.0.0" date="2021-10-07" urgency="medium">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Add 128px app icon (thanks to @hanaral)</li>
           <li>Rounded window corners on any stylesheet (thanks to @JeysonFlores)</li>
@@ -236,7 +236,7 @@
     </release>
 
     <release version="0.1.0" date="2021-10-01" urgency="medium">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Initial release</li>
         </ul>


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.