### PR TITLE
Flatpak: Regain access to HOME

### DIFF
--- a/com.github.ryonakano.pinit.yml
+++ b/com.github.ryonakano.pinit.yml
@@ -7,7 +7,7 @@ finish-args:
   - '--share=ipc'
   - '--socket=wayland'
   - '--socket=fallback-x11'
-  - '--filesystem=~/.local/share/applications'
+  - '--filesystem=home'
   # For drawing icons
   - '--device=dri'
 modules:


### PR DESCRIPTION
Fixes #113
Fixes #64
Fixes #61

While it it ideal to restrict filesystem permission, we've faced several issues due to this:

- Created desktop entries disappear after reboot/upgrade
- The path displayed in the entry is weird (/run/user/1000/...)

I thought making Pin It! copy the executable and icon files to ~/.local/share/applications where the desktop file is saved, because it would keep the filesystem permission as small as possible. However, it would need more considerations like the case when the size of the executable or icon file is huge (maybe we need some kind of the progress dialog...)

Considering these side effects, I think regaining access to HOME is simpler and better decision here.