### PR TITLE
Make app summary shorter than 35 characters

### DIFF
--- a/data/pinit.desktop.in
+++ b/data/pinit.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Pin It!
 GenericName=Desktop File Creator
-Comment=Pin shortcuts for your favorite portable apps to your app launcher
+Comment=Pin portable apps to the launcher
 Categories=System;Utility;
 Exec=com.github.ryonakano.pinit
 Icon=com.github.ryonakano.pinit

--- a/data/pinit.metainfo.xml.in
+++ b/data/pinit.metainfo.xml.in
@@ -8,7 +8,7 @@
   <project_license>GPL-3.0+</project_license>
 
   <name>Pin It!</name>
-  <summary>Pin shortcuts for your favorite portable apps to your app launcher</summary>
+  <summary>Pin portable apps to the launcher</summary>
   <description>
     <p>
       Pin shortcuts for portable apps like raw executable files, AppImage files, etc. to the app launcher on your desktop.

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -148,7 +148,7 @@ public class MainWindow : Adw.ApplicationWindow {
             application_icon = Constants.PROJECT_NAME,
             application_name = Constants.APP_NAME,
             version = Constants.PROJECT_VERSION,
-            comments = _("Pin shortcuts for your favorite portable apps to your app launcher"),
+            comments = _("Pin portable apps to the launcher"),
             website = "https://github.com/ryonakano/pinit",
             support_url = "https://github.com/ryonakano/pinit/discussions",
             issue_url = "https://github.com/ryonakano/pinit/issues",


### PR DESCRIPTION
Part of #123

```
ryo@b760m:~/work/ryonakano/pinit (shorten-app-summary)$ echo -n "Pin portable apps to the launcher" | wc -c
33
ryo@b760m:~/work/ryonakano/pinit (shorten-app-summary)$ 
```