### PR TITLE
MainWindow: Keep the view after saving

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -89,7 +89,6 @@ public class MainWindow : Adw.ApplicationWindow {
         });
 
         edit_view.file_updated.connect (() => {
-            show_files_view ();
             overlay.add_toast (updated_toast);
         });
 


### PR DESCRIPTION
It would be annoying if a user want to continue editing after that. Saving does not always mean completion of editing.