### PR TITLE
Revert "MainWindow: Fix unsaved dialog is shown after saving"

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -89,7 +89,6 @@ public class MainWindow : Adw.ApplicationWindow {
         });
 
         edit_view.file_updated.connect (() => {
-            backup_desktop_file = desktop_file;
             overlay.add_toast (updated_toast);
         });
 


### PR DESCRIPTION
Reverts ryonakano/pinit#141

This causes the issue that the unsaved dialog is never shown even modified after once saving, because this is a reference… 😵