### PR TITLE
Metainfo: Update app descriptions

### DIFF
--- a/data/pinit.metainfo.xml.in
+++ b/data/pinit.metainfo.xml.in
@@ -19,7 +19,6 @@
     <ul>
       <li>Edit or delete created app entries without opening the file manager</li>
       <li>Automatically add the execute permission to the file you select</li>
-      <li>Syntax error detection</li>
     </ul>
   </description>
 

--- a/data/pinit.metainfo.xml.in
+++ b/data/pinit.metainfo.xml.in
@@ -24,22 +24,22 @@
 
   <screenshots>
     <screenshot type="default">
-      <caption>FilesView in the light mode</caption>
+      <caption>List of app entries in the light mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/2.0.3/data/screenshots/gnome/screenshot-files-view-light.png</image>
     </screenshot>
 
     <screenshot>
-      <caption>EditView in the light mode</caption>
+      <caption>Editing the app entry in the light mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/2.0.3/data/screenshots/gnome/screenshot-edit-view-light.png</image>
     </screenshot>
 
     <screenshot>
-      <caption>FilesView in the dark mode</caption>
+      <caption>List of app entries in the dark mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/2.0.3/data/screenshots/gnome/screenshot-files-view-dark.png</image>
     </screenshot>
 
     <screenshot>
-      <caption>EditView in the dark mode</caption>
+      <caption>Editing the app entry in the dark mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/2.0.3/data/screenshots/gnome/screenshot-edit-view-dark.png</image>
     </screenshot>
   </screenshots>

--- a/data/pinit.metainfo.xml.in
+++ b/data/pinit.metainfo.xml.in
@@ -18,30 +18,29 @@
     </p>
     <ul>
       <li>Edit or delete created app entries without opening the file manager</li>
-      <li>Automatically add execution permission to the file you select</li>
+      <li>Automatically add the execute permission to the file you select</li>
       <li>Syntax error detection</li>
-      <li>Automatically save everything―your data in editing, last open view, and preferences</li>
     </ul>
   </description>
 
   <screenshots>
     <screenshot type="default">
-      <caption>Files view in the light mode</caption>
+      <caption>FilesView in the light mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/2.0.3/data/screenshots/gnome/screenshot-files-view-light.png</image>
     </screenshot>
 
     <screenshot>
-      <caption>Edit view in the light mode</caption>
+      <caption>EditView in the light mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/2.0.3/data/screenshots/gnome/screenshot-edit-view-light.png</image>
     </screenshot>
 
     <screenshot>
-      <caption>Files view in the dark mode</caption>
+      <caption>FilesView in the dark mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/2.0.3/data/screenshots/gnome/screenshot-files-view-dark.png</image>
     </screenshot>
 
     <screenshot>
-      <caption>Edit view in the dark mode</caption>
+      <caption>EditView in the dark mode</caption>
       <image>https://raw.githubusercontent.com/ryonakano/pinit/2.0.3/data/screenshots/gnome/screenshot-edit-view-dark.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
- Remove description about dropped feature
- Update caption text of screenshots
    - "Edit view" sounds like to edit the view and ambiguous
- "execute permission" sounds more common than "execution permission"