### PR TITLE
Widgets: Use getter/setter methods instead of properties

### DIFF
--- a/src/View/EditView.vala
+++ b/src/View/EditView.vala
@@ -332,7 +332,7 @@ public class View.EditView : Adw.NavigationPage {
                 return;
             }
 
-            desktop_file.set_string_list (KeyFileDesktop.KEY_CATEGORIES, categories_row.categories);
+            desktop_file.set_string_list (KeyFileDesktop.KEY_CATEGORIES, categories_row.to_strv ());
         });
 
         keywords_row.keywords_changed.connect (() => {
@@ -340,7 +340,7 @@ public class View.EditView : Adw.NavigationPage {
                 return;
             }
 
-            desktop_file.set_string_list (Define.KEY_KEYWORDS, keywords_row.keywords);
+            desktop_file.set_string_list (Define.KEY_KEYWORDS, keywords_row.to_strv ());
         });
 
         startup_wm_class_entry.notify["text"].connect (() => {
@@ -411,8 +411,8 @@ public class View.EditView : Adw.NavigationPage {
         locale = desktop_file.get_locale_for_key (KeyFileDesktop.KEY_COMMENT, Application.preferred_language);
         comment_entry.text = desktop_file.get_locale_string (KeyFileDesktop.KEY_COMMENT, locale, false);
 
-        categories_row.categories = desktop_file.get_string_list (KeyFileDesktop.KEY_CATEGORIES, false);
-        keywords_row.keywords = desktop_file.get_string_list (Define.KEY_KEYWORDS, false);
+        categories_row.from_strv (desktop_file.get_string_list (KeyFileDesktop.KEY_CATEGORIES, false));
+        keywords_row.from_strv (desktop_file.get_string_list (Define.KEY_KEYWORDS, false));
         startup_wm_class_entry.text = desktop_file.get_string (KeyFileDesktop.KEY_STARTUP_WM_CLASS, false);
         terminal_row.active = desktop_file.get_boolean (KeyFileDesktop.KEY_TERMINAL, false);
 

--- a/src/Widget/CategoriesRow.vala
+++ b/src/Widget/CategoriesRow.vala
@@ -11,52 +11,10 @@
  */
 public class Widget.CategoriesRow : Adw.ExpanderRow {
     /**
-     * A signal emitted when categories are changed.
+     * A signal emitted when categories are changed (specifically, when a {@link Adw.SwitchRow} in this
+     * is turned on / off).
      */
     public signal void categories_changed ();
-
-    /**
-     * Categories of the app.
-     */
-    public string[] categories {
-        owned get {
-            string[] _categories = {};
-
-            /*
-             * Each category has a switch row.
-             * If the switch row is activated, that means that category is selected,
-             * so we add the name of that category in the Categories section
-             * in the desktop file.
-             */
-            foreach (var item in row_items) {
-                if (item.row.active) {
-                    _categories += item.category;
-                }
-            }
-
-            return _categories;
-        }
-
-        /*
-         * Read the listed categories in the Categories section of the desktop file,
-         * and reflect them to the UI.
-         */
-        set {
-            foreach (var item in row_items) {
-                // Clear the current selection
-                item.row.active = false;
-
-                foreach (var category in value) {
-                    // The category is in the desktop file
-                    if (item.category == category) {
-                        item.row.active = true;
-                        // We find the category matching, so no longer need the rest of the loop.
-                        continue;
-                    }
-                }
-            }
-        }
-    }
 
     /**
      * Stores all of the switch rows in this expander row.
@@ -69,6 +27,9 @@ public class Widget.CategoriesRow : Adw.ExpanderRow {
      */
     private Gee.HashMap<string, string> categories_table;
 
+    /**
+     * The constructor.
+     */
     public CategoriesRow () {
     }
 
@@ -103,6 +64,54 @@ public class Widget.CategoriesRow : Adw.ExpanderRow {
             row_items.add (item);
             add_row (item.row);
         }
+    }
+
+    /**
+     * Return categories in a string array.
+     *
+     * @return categories represented in a string array
+     */
+    public string[] to_strv () {
+        string[] _categories = {};
+
+        /*
+         * Each category has a switch row.
+         * If the switch row is activated, that means that category is selected,
+         * so we add the name of that category in the Categories section
+         * in the desktop file.
+         */
+        row_items.foreach ((item) => {
+            if (item.row.active) {
+                _categories += item.category;
+            }
+
+            return true;
+        });
+
+        return _categories;
+    }
+
+    /**
+     * Reflect categories in a string array to the UI.
+     *
+     * @param categories categories represented in a string array
+     */
+    public void from_strv (string[] categories) {
+        row_items.foreach ((item) => {
+            // Clear the current selection
+            item.row.active = false;
+
+            foreach (unowned string category in categories) {
+                // The category is in the desktop file
+                if (item.category == category) {
+                    item.row.active = true;
+                    // We find the category matching, so no longer need the rest of the loop.
+                    continue;
+                }
+            }
+
+            return true;
+        });
     }
 
     private class RowItem : Object {

--- a/src/Widget/KeywordsRow.vala
+++ b/src/Widget/KeywordsRow.vala
@@ -15,38 +15,13 @@ public class Widget.KeywordsRow : Adw.ExpanderRow {
     public signal void keywords_changed ();
 
     /**
-     * Keywords of the app.
-     */
-    public string[] keywords {
-        owned get {
-            string[] _keywords = {};
-
-            rows.foreach ((row) => {
-                _keywords += row.text;
-                return true;
-            });
-
-            return _keywords;
-        }
-
-        set {
-            // Clear all of the currently added entries
-            rows.foreach ((row) => {
-                remove_row (row);
-                return true;
-            });
-
-            foreach (unowned string keyword in value) {
-                add_keyword (keyword);
-            }
-        }
-    }
-
-    /**
      * Stores all of the rows in this expander row.
      */
     private Gee.ArrayList<KeywordRow> rows;
 
+    /**
+     * The constructor.
+     */
     public KeywordsRow () {
     }
 
@@ -67,6 +42,39 @@ public class Widget.KeywordsRow : Adw.ExpanderRow {
             expanded = true;
             add_keyword ();
         });
+    }
+
+    /**
+     * Return keywords in a string array.
+     *
+     * @return keywords represented in a string array
+     */
+    public string[] to_strv () {
+        string[] _keywords = {};
+
+        rows.foreach ((row) => {
+            _keywords += row.text;
+            return true;
+        });
+
+        return _keywords;
+    }
+
+    /**
+     * Reflect keywords in a string array to the UI.
+     *
+     * @param keywords keywords represented in a string array
+     */
+    public void from_strv (string[] keywords) {
+        // Clear all of the currently added entries
+        rows.foreach ((row) => {
+            remove_row (row);
+            return true;
+        });
+
+        foreach (unowned string keyword in keywords) {
+            add_keyword (keyword);
+        }
     }
 
     /**


### PR DESCRIPTION
They're not intended to be used like: `notify["categories"]`