### PR TITLE
Improve error handling and logs

### DIFF
--- a/src/Model/DesktopFile.vala
+++ b/src/Model/DesktopFile.vala
@@ -82,8 +82,8 @@ public class Model.DesktopFile : Object {
 
         try {
             val = keyfile.get_boolean (KeyFileDesktop.GROUP, key);
-        } catch (KeyFileError e) {
-            warning ("Failed to KeyFile.get_boolean: key=%s: %s", key, e.message);
+        } catch (KeyFileError err) {
+            warning ("Failed to KeyFile.get_boolean: key=%s: %s", key, err.message);
         }
 
         return val;
@@ -106,8 +106,8 @@ public class Model.DesktopFile : Object {
 
         try {
             val = keyfile.get_string (KeyFileDesktop.GROUP, key);
-        } catch (KeyFileError e) {
-            warning ("Failed to KeyFile.get_string: key=%s: %s", key, e.message);
+        } catch (KeyFileError err) {
+            warning ("Failed to KeyFile.get_string: key=%s: %s", key, err.message);
         }
 
         return val;
@@ -118,8 +118,8 @@ public class Model.DesktopFile : Object {
 
         try {
             ret = keyfile.has_key (KeyFileDesktop.GROUP, key);
-        } catch (KeyFileError e) {
-            warning ("Failed to KeyFile.has_key: key=%s: %s", key, e.message);
+        } catch (KeyFileError err) {
+            warning ("Failed to KeyFile.has_key: key=%s: %s", key, err.message);
         }
 
         return ret;
@@ -142,8 +142,8 @@ public class Model.DesktopFile : Object {
 
         try {
             val = keyfile.get_string_list (KeyFileDesktop.GROUP, key);
-        } catch (KeyFileError e) {
-            warning ("Failed to KeyFile.get_string_list: key=%s: %s", key, e.message);
+        } catch (KeyFileError err) {
+            warning ("Failed to KeyFile.get_string_list: key=%s: %s", key, err.message);
         }
 
         return val;
@@ -158,8 +158,8 @@ public class Model.DesktopFile : Object {
             if (has_key (key)) {
                 try {
                     keyfile.remove_key (KeyFileDesktop.GROUP, key);
-                } catch (KeyFileError e) {
-                    warning ("Failed to KeyFile.remove_key: key=%s: %s", key, e.message);
+                } catch (KeyFileError err) {
+                    warning ("Failed to KeyFile.remove_key: key=%s: %s", key, err.message);
                 }
             }
         }
@@ -174,8 +174,8 @@ public class Model.DesktopFile : Object {
             if (has_key (key)) {
                 try {
                     keyfile.remove_key (KeyFileDesktop.GROUP, key);
-                } catch (KeyFileError e) {
-                    warning ("Failed to KeyFile.remove_key: key=%s: %s", key, e.message);
+                } catch (KeyFileError err) {
+                    warning ("Failed to KeyFile.remove_key: key=%s: %s", key, err.message);
                 }
             }
         }
@@ -190,8 +190,8 @@ public class Model.DesktopFile : Object {
             if (has_key (key)) {
                 try {
                     keyfile.remove_key (KeyFileDesktop.GROUP, key);
-                } catch (KeyFileError e) {
-                    warning ("Failed to KeyFile.remove_key: key=%s: %s", key, e.message);
+                } catch (KeyFileError err) {
+                    warning ("Failed to KeyFile.remove_key: key=%s: %s", key, err.message);
                 }
             }
         }
@@ -206,8 +206,8 @@ public class Model.DesktopFile : Object {
 
         try {
             ret = keyfile.load_from_data (data, data.length, KeyFileFlags.KEEP_TRANSLATIONS);
-        } catch (KeyFileError e) {
-            warning ("Failed to KeyFile.load_from_data: %s", e.message);
+        } catch (KeyFileError err) {
+            warning ("Failed to KeyFile.load_from_data: %s", err.message);
         }
 
         return ret;
@@ -245,8 +245,8 @@ public class Model.DesktopFile : Object {
 
         try {
             val = keyfile.get_locale_string (KeyFileDesktop.GROUP, key, locale);
-        } catch (KeyFileError e) {
-            warning ("Failed to KeyFile.get_locale_string: key=%s: %s", key, e.message);
+        } catch (KeyFileError err) {
+            warning ("Failed to KeyFile.get_locale_string: key=%s: %s", key, err.message);
         }
 
         return val;
@@ -263,10 +263,10 @@ public class Model.DesktopFile : Object {
 
         try {
             ret = keyfile.load_from_file (path, KeyFileFlags.KEEP_TRANSLATIONS);
-        } catch (FileError e) {
-            warning ("Failed to load from file. path=%s: %s", path, e.message);
-        } catch (KeyFileError e) {
-            warning ("Invalid keyfile. path=%s: %s", path, e.message);
+        } catch (FileError err) {
+            warning ("Failed to load from file. path=%s: %s", path, err.message);
+        } catch (KeyFileError err) {
+            warning ("Invalid keyfile. path=%s: %s", path, err.message);
         }
 
         return ret;
@@ -277,8 +277,8 @@ public class Model.DesktopFile : Object {
 
         try {
             ret = keyfile.save_to_file (path);
-        } catch (FileError e) {
-            warning ("Failed to save file. path=%s: %s", path, e.message);
+        } catch (FileError err) {
+            warning ("Failed to save file. path=%s: %s", path, err.message);
         }
 
         return ret;
@@ -290,8 +290,8 @@ public class Model.DesktopFile : Object {
 
         try {
             ret = file.delete ();
-        } catch (Error e) {
-            warning ("Failed to delete file. path=%s: %s", path, e.message);
+        } catch (Error err) {
+            warning ("Failed to delete file. path=%s: %s", path, err.message);
         }
 
         return ret;
@@ -314,9 +314,9 @@ public class Model.DesktopFile : Object {
         bool ret = false;
         try {
             ret = yield file_launcher.launch (parent, null);
-        } catch (Error e) {
-            warning ("Failed to open file externally. path=%s: %s", path, e.message);
-            throw e;
+        } catch (Error err) {
+            warning ("Failed to open file externally. path=%s: %s", path, err.message);
+            throw err;
         }
 
         return ret;

--- a/src/View/EditView.vala
+++ b/src/View/EditView.vala
@@ -248,8 +248,8 @@ public class View.EditView : Adw.NavigationPage {
                     exec_entry.text = path;
                     desktop_file.set_string (KeyFileDesktop.KEY_EXEC, path);
                     set_save_button_sensitivity ();
-                } catch (Error e) {
-                    warning ("Failed to select executable file: %s", e.message);
+                } catch (Error err) {
+                    warning ("Failed to select executable file: %s", err.message);
                 }
             });
         });
@@ -261,8 +261,8 @@ public class View.EditView : Adw.NavigationPage {
 
             try {
                 icon_image.gicon = Icon.new_for_string (icon_entry.text);
-            } catch (Error e) {
-                warning ("Failed to update icon_image: %s", e.message);
+            } catch (Error err) {
+                warning ("Failed to update icon_image: %s", err.message);
             }
 
             desktop_file.set_string (KeyFileDesktop.KEY_ICON, icon_entry.text);
@@ -305,8 +305,8 @@ public class View.EditView : Adw.NavigationPage {
 
                     icon_entry.text = path;
                     desktop_file.set_string (KeyFileDesktop.KEY_ICON, path);
-                } catch (Error e) {
-                    warning ("Failed to select icon file: %s", e.message);
+                } catch (Error err) {
+                    warning ("Failed to select icon file: %s", err.message);
                 }
             });
         });
@@ -403,8 +403,8 @@ public class View.EditView : Adw.NavigationPage {
 
         try {
             icon_image.gicon = Icon.new_for_string (icon);
-        } catch (Error e) {
-            warning ("Failed to update icon_image: %s", e.message);
+        } catch (Error err) {
+            warning ("Failed to update icon_image: %s", err.message);
         }
 
         string locale = desktop_file.get_locale_for_key (KeyFileDesktop.KEY_NAME, Application.preferred_language);

--- a/src/View/FilesView.vala
+++ b/src/View/FilesView.vala
@@ -113,8 +113,8 @@ public class View.FilesView : Adw.NavigationPage {
         };
         try {
             app_icon.gicon = Icon.new_for_string (file.get_string (KeyFileDesktop.KEY_ICON, false));
-        } catch (Error e) {
-            warning ("Failed to update app_icon: %s", e.message);
+        } catch (Error err) {
+            warning ("Failed to update app_icon: %s", err.message);
         }
 
         string locale = file.get_locale_for_key (KeyFileDesktop.KEY_NAME, Application.preferred_language);


### PR DESCRIPTION
- Do not use one-word variable for searchability
- Add literal log message with error message for searchability
- Do not bundle multiple throws with one catch