### PR TITLE
chore: Actions: Separate steps per manifest

### DIFF
--- a/.github/workflows/flatpak-x-checker.yml
+++ b/.github/workflows/flatpak-x-checker.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run flatpak-external-data-checker
+      - name: Update Flathub development manifest
         uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
@@ -23,7 +23,28 @@ jobs:
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --update --never-fork
-            com.github.ryonakano.pinit.yml
-            build-aux/appcenter/com.github.ryonakano.pinit.Devel.yml
-            build-aux/flathub/com.github.ryonakano.pinit.Devel.yml
+          args: --update --never-fork build-aux/flathub/com.github.ryonakano.pinit.Devel.yml
+
+      - name: Update AppCenter development manifest
+        uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.com/orgs/community/discussions/26560
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork build-aux/appcenter/com.github.ryonakano.pinit.Devel.yml
+
+      - name: Update AppCenter stable manifest
+        uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.com/orgs/community/discussions/26560
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork com.github.ryonakano.pinit.yml


### PR DESCRIPTION
Because the checker doesn't seem to accept multiple manifests:

```
[ryo@b760m ~/work/ryonakano/pinit (flatpak-x-checker-separate-steps)]$ flatpak run org.flathub.flatpak-external-data-checker --never-fork --edit-only ./build-aux/appcenter/com.github.ryonakano.pinit.Devel.yml  ./build-aux/flathub/com.github.ryonakano.pinit.Devel.yml  ./com.github.ryonakano.pinit.yml
usage: flatpak-external-data-checker [-h] [-v] [--update] [--commit-only] [--edit-only] [--check-outdated] [--filter-type {extra-data,file,archive,git}]
                                     [--always-fork | --never-fork] [--unsafe] [--max-manifest-size MAX_MANIFEST_SIZE] [--require-important-update]
                                     manifest
flatpak-external-data-checker: error: unrecognized arguments: ./build-aux/flathub/com.github.ryonakano.pinit.Devel.yml ./com.github.ryonakano.pinit.yml
[ryo@b760m ~/work/ryonakano/pinit (flatpak-x-checker-separate-steps)]$
```