### PR TITLE
Compare content of KeyFile in DesktopFile class & lessen disk access

### DIFF
--- a/src/Model/DesktopFile.vala
+++ b/src/Model/DesktopFile.vala
@@ -416,29 +416,4 @@ public class Model.DesktopFile : Object {
 
         return ret;
     }
-
-    /**
-     * Open the desktop file associated with this in an external editor.
-     *
-     * @param parent the parent GtkWindow
-     * @return true if successfully opened this, false otherwise
-     * @throws Error failed to open this externally
-     */
-    public async bool open_external (Gtk.Window? parent) throws Error {
-        var file = File.new_for_path (path);
-
-        var file_launcher = new Gtk.FileLauncher (file) {
-            always_ask = true
-        };
-
-        bool ret = false;
-        try {
-            ret = yield file_launcher.launch (parent, null);
-        } catch (Error err) {
-            warning ("Failed to open file externally. path=%s: %s", path, err.message);
-            throw err;
-        }
-
-        return ret;
-    }
 }

--- a/src/Model/DesktopFile.vala
+++ b/src/Model/DesktopFile.vala
@@ -164,7 +164,7 @@ public class Model.DesktopFile : Object {
      */
     public bool is_clean {
         get {
-            return equals_keyfile (keyfile_ditry, keyfile_clean);
+            return equals_keyfile (keyfile_dirty, keyfile_clean);
         }
     }
 
@@ -175,7 +175,7 @@ public class Model.DesktopFile : Object {
     /**
      * Data in a single desktop file that may contain unsaved changes to the disk.
      */
-    private KeyFile keyfile_ditry;
+    private KeyFile keyfile_dirty;
 
     /**
      * The constructor.
@@ -190,7 +190,7 @@ public class Model.DesktopFile : Object {
 
     construct {
         keyfile_clean = new KeyFile ();
-        keyfile_ditry = new KeyFile ();
+        keyfile_dirty = new KeyFile ();
     }
 
     /**
@@ -248,7 +248,7 @@ public class Model.DesktopFile : Object {
         }
 
         try {
-            val = keyfile_ditry.get_boolean (KeyFileDesktop.GROUP, key);
+            val = keyfile_dirty.get_boolean (KeyFileDesktop.GROUP, key);
         } catch (KeyFileError err) {
             warning ("Failed to KeyFile.get_boolean: key=%s: %s", key, err.message);
         }
@@ -264,7 +264,7 @@ public class Model.DesktopFile : Object {
         }
 
         try {
-            val = keyfile_ditry.get_string (KeyFileDesktop.GROUP, key);
+            val = keyfile_dirty.get_string (KeyFileDesktop.GROUP, key);
         } catch (KeyFileError err) {
             warning ("Failed to KeyFile.get_string: key=%s: %s", key, err.message);
         }
@@ -275,13 +275,13 @@ public class Model.DesktopFile : Object {
     public bool has_key (string key) {
         bool ret = false;
 
-        // Maybe keyfile_ditry is new and has no key yet
-        if (!keyfile_ditry.has_group (KeyFileDesktop.GROUP)) {
+        // Maybe keyfile_dirty is new and has no key yet
+        if (!keyfile_dirty.has_group (KeyFileDesktop.GROUP)) {
             return ret;
         }
 
         try {
-            ret = keyfile_ditry.has_key (KeyFileDesktop.GROUP, key);
+            ret = keyfile_dirty.has_key (KeyFileDesktop.GROUP, key);
         } catch (KeyFileError err) {
             warning ("Failed to KeyFile.has_key: key=%s: %s", key, err.message);
         }
@@ -297,7 +297,7 @@ public class Model.DesktopFile : Object {
         }
 
         try {
-            val = keyfile_ditry.get_string_list (KeyFileDesktop.GROUP, key);
+            val = keyfile_dirty.get_string_list (KeyFileDesktop.GROUP, key);
         } catch (KeyFileError err) {
             warning ("Failed to KeyFile.get_string_list: key=%s: %s", key, err.message);
         }
@@ -308,12 +308,12 @@ public class Model.DesktopFile : Object {
     public void set_boolean (string key, bool val) {
         if (val) {
             // Update the value when the corresponding entry has some value.
-            keyfile_ditry.set_boolean (KeyFileDesktop.GROUP, key, val);
+            keyfile_dirty.set_boolean (KeyFileDesktop.GROUP, key, val);
         } else {
             // Remove the key when it exists and the corresponding entry has no value.
             if (has_key (key)) {
                 try {
-                    keyfile_ditry.remove_key (KeyFileDesktop.GROUP, key);
+                    keyfile_dirty.remove_key (KeyFileDesktop.GROUP, key);
                 } catch (KeyFileError err) {
                     warning ("Failed to KeyFile.remove_key: key=%s: %s", key, err.message);
                 }
@@ -324,12 +324,12 @@ public class Model.DesktopFile : Object {
     public void set_string (string key, string val) {
         if (val != "") {
             // Update the value when the corresponding entry has some value.
-            keyfile_ditry.set_string (KeyFileDesktop.GROUP, key, val);
+            keyfile_dirty.set_string (KeyFileDesktop.GROUP, key, val);
         } else {
             // Remove the key when it exists and the corresponding entry has no value.
             if (has_key (key)) {
                 try {
-                    keyfile_ditry.remove_key (KeyFileDesktop.GROUP, key);
+                    keyfile_dirty.remove_key (KeyFileDesktop.GROUP, key);
                 } catch (KeyFileError err) {
                     warning ("Failed to KeyFile.remove_key: key=%s: %s", key, err.message);
                 }
@@ -340,12 +340,12 @@ public class Model.DesktopFile : Object {
     public void set_string_list (string key, string[] list) {
         if (list.length > 0) {
             // Update the value when the corresponding entry has some value.
-            keyfile_ditry.set_string_list (KeyFileDesktop.GROUP, key, list);
+            keyfile_dirty.set_string_list (KeyFileDesktop.GROUP, key, list);
         } else {
             // Remove the key when it exists and the corresponding entry has no value.
             if (has_key (key)) {
                 try {
-                    keyfile_ditry.remove_key (KeyFileDesktop.GROUP, key);
+                    keyfile_dirty.remove_key (KeyFileDesktop.GROUP, key);
                 } catch (KeyFileError err) {
                     warning ("Failed to KeyFile.remove_key: key=%s: %s", key, err.message);
                 }
@@ -360,7 +360,7 @@ public class Model.DesktopFile : Object {
     ////////////////////////////////////////////////////////////////////////////
 
     public string? get_locale_for_key (string key, string? locale = null) {
-        return keyfile_ditry.get_locale_for_key (KeyFileDesktop.GROUP, key, locale);
+        return keyfile_dirty.get_locale_for_key (KeyFileDesktop.GROUP, key, locale);
     }
 
     public string get_locale_string (string key, string? locale = null) {
@@ -371,7 +371,7 @@ public class Model.DesktopFile : Object {
         }
 
         try {
-            val = keyfile_ditry.get_locale_string (KeyFileDesktop.GROUP, key, locale);
+            val = keyfile_dirty.get_locale_string (KeyFileDesktop.GROUP, key, locale);
         } catch (KeyFileError err) {
             warning ("Failed to KeyFile.get_locale_string: key=%s: %s", key, err.message);
         }
@@ -392,21 +392,21 @@ public class Model.DesktopFile : Object {
             warning ("Failed to load from file. path=%s: %s", path, err.message);
             return false;
         } catch (KeyFileError err) {
-            warning ("Invalid keyfile_ditry. path=%s: %s", path, err.message);
+            warning ("Invalid keyfile_dirty. path=%s: %s", path, err.message);
             return false;
         }
 
-        return copy_keyfile (keyfile_ditry, keyfile_clean);
+        return copy_keyfile (keyfile_dirty, keyfile_clean);
     }
 
     public bool save_file () {
         try {
-            keyfile_ditry.save_to_file (path);
+            keyfile_dirty.save_to_file (path);
         } catch (FileError err) {
             warning ("Failed to save file. path=%s: %s", path, err.message);
         }
 
-        return copy_keyfile (keyfile_clean, keyfile_ditry);
+        return copy_keyfile (keyfile_clean, keyfile_dirty);
     }
 
     public bool delete_file () {

--- a/src/Model/DesktopFile.vala
+++ b/src/Model/DesktopFile.vala
@@ -353,22 +353,6 @@ public class Model.DesktopFile : Object {
         }
     }
 
-    public string to_data () {
-        return keyfile_ditry.to_data ();
-    }
-
-    public bool load_from_data (string data) {
-        bool ret = false;
-
-        try {
-            ret = keyfile_ditry.load_from_data (data, data.length, KeyFileFlags.KEEP_TRANSLATIONS);
-        } catch (KeyFileError err) {
-            warning ("Failed to KeyFile.load_from_data: %s", err.message);
-        }
-
-        return ret;
-    }
-
     ////////////////////////////////////////////////////////////////////////////
     //
     // Localized Key Opearations

--- a/src/Model/DesktopFile.vala
+++ b/src/Model/DesktopFile.vala
@@ -153,6 +153,39 @@ public class Model.DesktopFile : Object {
     }
 
     /**
+     * Value of "Name" entry without unsaved changes.
+     */
+    public string saved_value_name {
+        owned get {
+            string? locale = Util.KeyFileUtil.get_locale_for_key (keyfile_clean, KeyFileDesktop.KEY_NAME, Application.preferred_language);
+            string name = Util.KeyFileUtil.get_locale_string (keyfile_clean, KeyFileDesktop.KEY_NAME, locale);
+
+            return name;
+        }
+    }
+
+    /**
+     * Value of "Icon" entry without unsaved changes.
+     */
+    public string saved_value_icon {
+        owned get {
+            return Util.KeyFileUtil.get_string (keyfile_clean, KeyFileDesktop.KEY_ICON);
+        }
+    }
+
+    /**
+     * Value of "Comment" entry without unsaved changes.
+     */
+    public string saved_value_comment {
+        owned get {
+            string? locale = Util.KeyFileUtil.get_locale_for_key (keyfile_clean, KeyFileDesktop.KEY_COMMENT, Application.preferred_language);
+            string comment = Util.KeyFileUtil.get_locale_string (keyfile_clean, KeyFileDesktop.KEY_COMMENT, locale);
+
+            return comment;
+        }
+    }
+
+    /**
      * Returns if this contains unsaved changes to the disk.
      */
     public bool is_clean {

--- a/src/Model/DesktopFile.vala
+++ b/src/Model/DesktopFile.vala
@@ -209,17 +209,4 @@ public class Model.DesktopFile : Object {
 
         return Util.KeyFileUtil.copy (keyfile_clean, keyfile_dirty);
     }
-
-    public bool delete_file () {
-        var file = File.new_for_path (path);
-        bool ret = false;
-
-        try {
-            ret = file.delete ();
-        } catch (Error err) {
-            warning ("Failed to delete file. path=%s: %s", path, err.message);
-        }
-
-        return ret;
-    }
 }

--- a/src/Model/DesktopFileModel.vala
+++ b/src/Model/DesktopFileModel.vala
@@ -120,4 +120,63 @@ public class Model.DesktopFileModel : Object {
             load_failure ();
         }
     }
+
+    /**
+     * Create a new {@link DesktopFile} with random filename.
+     *
+     * @return Created {@link DesktopFile}
+     */
+    public Model.DesktopFile create_file () {
+        string filename = Config.APP_ID + "." + Uuid.string_random ();
+        string path = Path.build_filename (
+            desktop_files_path,
+            filename + Model.DesktopFile.DESKTOP_SUFFIX
+        );
+
+        var file = new Model.DesktopFile (path);
+
+        files_list.add (file);
+
+        return file;
+    }
+
+    /**
+     * Delete desktop file from list and the disk.
+     *
+     * @param file A {@link DesktopFile} to delete
+     * @return true if succeeded, false otherwise
+     */
+    public bool delete_file (Model.DesktopFile file) {
+        bool ret = delete_from_disk (file.path);
+        if (!ret) {
+            return false;
+        }
+
+        files_list.remove (file);
+
+        return true;
+    }
+
+    /**
+     * Delete file at path from the disk.
+     *
+     * @param path A file to delete
+     * @return true if succeeded, false otherwise
+     */
+    private bool delete_from_disk (string path) {
+        var file = File.new_for_path (path);
+
+        if (!file.query_exists ()) {
+            return true;
+        }
+
+        bool ret = false;
+        try {
+            ret = file.delete ();
+        } catch (Error err) {
+            warning ("Failed to delete file. path=%s: %s", path, err.message);
+        }
+
+        return ret;
+    }
 }

--- a/src/View/EditView.vala
+++ b/src/View/EditView.vala
@@ -363,11 +363,11 @@ public class View.EditView : Adw.NavigationPage {
         });
 
         open_text_editor_button.clicked.connect (() => {
-            desktop_file.open_external.begin ((Gtk.Window) get_root (), (obj, res) => {
+            open_external.begin (desktop_file.path, (obj, res) => {
                 bool ret;
 
                 try {
-                    ret = desktop_file.open_external.end (res);
+                    ret = open_external.end (res);
                 } catch (Error err) {
                     // The calling method is responsible for showing the error log.
 
@@ -493,5 +493,23 @@ public class View.EditView : Adw.NavigationPage {
      */
     private void set_save_button_sensitivity () {
         save_button.sensitive = (name_entry.text.length > 0 && exec_entry.text.length > 0);
+    }
+
+    private async bool open_external (string path) throws Error {
+        var file = File.new_for_path (path);
+
+        var file_launcher = new Gtk.FileLauncher (file) {
+            always_ask = true
+        };
+
+        bool ret = false;
+        try {
+            ret = yield file_launcher.launch ((Gtk.Window) get_root (), null);
+        } catch (Error err) {
+            warning ("Failed to open file externally. path=%s: %s", path, err.message);
+            throw err;
+        }
+
+        return ret;
     }
 }

--- a/src/View/FilesView.vala
+++ b/src/View/FilesView.vala
@@ -5,7 +5,7 @@
 
 public class View.FilesView : Adw.NavigationPage {
     public signal void new_activated ();
-    public signal void deleted (bool is_success);
+    public signal void delete_activated (Model.DesktopFile file);
     public signal void selected (Model.DesktopFile file);
 
     private ListStore list_store;
@@ -106,6 +106,8 @@ public class View.FilesView : Adw.NavigationPage {
     private Gtk.Widget create_files_row (Object item) {
         var file = item as Model.DesktopFile;
 
+        string app_name = file.value_name;
+
         var app_icon = new Gtk.Image.from_gicon (new ThemedIcon ("application-x-executable")) {
             pixel_size = 48,
             margin_top = 6,
@@ -123,39 +125,23 @@ public class View.FilesView : Adw.NavigationPage {
         };
         delete_button.add_css_class ("flat");
         delete_button.clicked.connect (() => {
-            var delete_dialog = setup_delete_dialog (file.value_name);
+            var delete_dialog = setup_delete_dialog (app_name);
 
             delete_dialog.response.connect ((response_id) => {
                 if (response_id != Define.DialogResponse.OK) {
                     return;
                 }
 
-                bool ret = file.delete_file ();
-                if (!ret) {
-                    var error_dialog = new Adw.MessageDialog (
-                        (Gtk.Window) get_root (),
-                        _("Failed to Delete Entry of “%s”").printf (file.value_name),
-                        _("There was an error while removing the app entry.")
-                    );
-
-                    error_dialog.add_response (Define.DialogResponse.CLOSE, _("_Close"));
-
-                    error_dialog.default_response = Define.DialogResponse.CLOSE;
-                    error_dialog.close_response = Define.DialogResponse.CLOSE;
-
-                    error_dialog.present ();
-                }
-
-                deleted (ret);
-
                 delete_dialog.destroy ();
+
+                delete_activated (file);
             });
 
             delete_dialog.present ();
         });
 
         var row = new Adw.ActionRow () {
-            title = file.value_name,
+            title = app_name,
             subtitle = file.value_comment,
             title_lines = 1,
             subtitle_lines = 1,

--- a/src/View/FilesView.vala
+++ b/src/View/FilesView.vala
@@ -106,15 +106,13 @@ public class View.FilesView : Adw.NavigationPage {
     private Gtk.Widget create_files_row (Object item) {
         var file = item as Model.DesktopFile;
 
-        string app_name = file.value_name;
-
         var app_icon = new Gtk.Image.from_gicon (new ThemedIcon ("application-x-executable")) {
             pixel_size = 48,
             margin_top = 6,
             margin_bottom = 6
         };
         try {
-            app_icon.gicon = Icon.new_for_string (file.value_icon);
+            app_icon.gicon = Icon.new_for_string (file.saved_value_icon);
         } catch (Error err) {
             warning ("Failed to update app_icon: %s", err.message);
         }
@@ -125,7 +123,7 @@ public class View.FilesView : Adw.NavigationPage {
         };
         delete_button.add_css_class ("flat");
         delete_button.clicked.connect (() => {
-            var delete_dialog = setup_delete_dialog (app_name);
+            var delete_dialog = setup_delete_dialog (file.saved_value_name);
 
             delete_dialog.response.connect ((response_id) => {
                 if (response_id != Define.DialogResponse.OK) {
@@ -141,8 +139,8 @@ public class View.FilesView : Adw.NavigationPage {
         });
 
         var row = new Adw.ActionRow () {
-            title = app_name,
-            subtitle = file.value_comment,
+            title = file.saved_value_name,
+            subtitle = file.saved_value_comment,
             title_lines = 1,
             subtitle_lines = 1,
             activatable = true


### PR DESCRIPTION
MainWindow is not obliged to keep instances of unsaved DesktopFile and saved DesktopFile. We just compare only the KeyFile in DesktopFile anyways, so make DesktopFile do that job instead.