### PR TITLE
Flatpak: Use id instead of deprecated app-id

### DIFF
--- a/build-aux/appcenter/com.github.ryonakano.pinit.Devel.yml
+++ b/build-aux/appcenter/com.github.ryonakano.pinit.Devel.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.pinit.Devel
+id: com.github.ryonakano.pinit.Devel
 runtime: io.elementary.Platform
 runtime-version: '8'
 sdk: io.elementary.Sdk

--- a/build-aux/flathub/com.github.ryonakano.pinit.Devel.yml
+++ b/build-aux/flathub/com.github.ryonakano.pinit.Devel.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.pinit.Devel
+id: com.github.ryonakano.pinit.Devel
 runtime: org.gnome.Platform
 runtime-version: '47'
 sdk: org.gnome.Sdk

--- a/com.github.ryonakano.pinit.yml
+++ b/com.github.ryonakano.pinit.yml
@@ -1,4 +1,4 @@
-app-id: com.github.ryonakano.pinit
+id: com.github.ryonakano.pinit
 runtime: io.elementary.Platform
 runtime-version: '8'
 sdk: io.elementary.Sdk


### PR DESCRIPTION
From https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html:

> Note, "app-id" is deprecated and preserved only for backwards compatibility.