### PR TITLE
metainfo: Use revision instead of version for screenshots URL

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -31,7 +31,7 @@ appstream_conf.set('APP_ID', app_id)
 appstream_conf.set('GETTEXT_PACKAGE', meson.project_name())
 # Use screenshots taken on Pantheon, which is a publishing requirement for AppCenter, if build with granite.
 appstream_conf.set('DE', get_option('granite').enabled() ? 'pantheon' : 'gnome')
-appstream_conf.set('VERSION', meson.project_version())
+appstream_conf.set('APP_REVISION', app_revision)
 appstream_file_in = configure_file(
   input: 'pinit.metainfo.xml.in.in',
   output: '@0@.metainfo.xml.in'.format(app_id),

--- a/data/pinit.metainfo.xml.in.in
+++ b/data/pinit.metainfo.xml.in.in
@@ -25,12 +25,12 @@
   <screenshots>
     <screenshot type="default">
       <caption>App window in the light mode</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/pinit/@VERSION@/data/screenshots/@DE@/screenshot-light.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/pinit/@APP_REVISION@/data/screenshots/@DE@/screenshot-light.png</image>
     </screenshot>
 
     <screenshot>
       <caption>App window in the dark mode</caption>
-      <image>https://raw.githubusercontent.com/ryonakano/pinit/@VERSION@/data/screenshots/@DE@/screenshot-dark.png</image>
+      <image>https://raw.githubusercontent.com/ryonakano/pinit/@APP_REVISION@/data/screenshots/@DE@/screenshot-dark.png</image>
     </screenshot>
   </screenshots>
 

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project(
 app_name = 'Pin It!'
 app_id = meson.project_name()
 app_version = meson.project_version()
+app_revision = meson.project_version()
 if get_option('development')
   app_name += ' (Development)'
   app_id += '.Devel'
@@ -15,8 +16,12 @@ if get_option('development')
   ret = run_command('git', 'rev-parse', '--short', 'HEAD', check: false)
   if ret.returncode() != 0
     version_suffix = '-devel'
+    # Fallback to the default branch name
+    app_revision = 'main'
   else
-    version_suffix = '-@0@'.format(ret.stdout().strip())
+    rev = ret.stdout().strip()
+    version_suffix = '-@0@'.format(rev)
+    app_revision = rev
   endif
 
   app_version += version_suffix


### PR DESCRIPTION
Fixes `appstream-missing-screenshots` linter error on Flathub on the release branches. This allows us to make sure the build succeeds on Flathub using release candidates.
