### PR TITLE
chore: valadoc: DRY dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You'll need the following dependencies to build:
 * libglib2.0-dev (>= 2.74)
 * libgranite-7-dev (>= 7.2.0, required only when you build with `granite` feature enabled)
 * libgtk-4-dev (>= 4.10)
-* meson (>= 0.58.0)
+* meson (>= 1.5.0)
 * valac
 
 Run `meson setup` to configure the build environment and run `meson compile` to build:

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,0 +1,30 @@
+valadoc = find_program('valadoc')
+
+valadoc_pkgs = []
+foreach dep : dependencies
+  if not dep.found()
+    continue
+  endif
+
+  valadoc_pkgs += '--pkg=@0@'.format(dep.name())
+endforeach
+
+valadoc_output_dir = 'valadoc'
+valadoc_target = custom_target(
+  'valadoc',
+  command: [
+    valadoc,
+    valadoc_pkgs,
+    sources,
+    config_file,
+    '--package-name=' + meson.project_name(),
+    '--package-version=' + meson.project_version(),
+    '--verbose',
+    '--force',
+    '--use-svg-images',
+    '-o', valadoc_output_dir,
+  ],
+
+  build_by_default: true,
+  output: valadoc_output_dir,
+)

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'com.github.ryonakano.pinit',
   'vala', 'c',
   version: '2.2.1',
-  meson_version: '>= 0.58.0',
+  meson_version: '>= 1.5.0',
 )
 
 app_name = 'Pin It!'
@@ -36,9 +36,29 @@ add_project_arguments(
   language: 'c',
 )
 
+granite_dep = dependency('granite-7', version: '>= 7.2.0', required: get_option('granite'))
+if granite_dep.found()
+  add_project_arguments('--define=USE_GRANITE', language: 'vala')
+endif
+
+dependencies = [
+  dependency('gee-0.8'),
+  dependency('gio-unix-2.0'),
+  dependency('glib-2.0', version: '>= 2.74'),
+  granite_dep,
+  dependency('gtk4', version: '>= 4.10'),
+  dependency('libadwaita-1', version: '>= 1.5.0'),
+  dependency('pango'),
+  meson.get_compiler('vala').find_library('posix'),
+]
+
 subdir('data')
 subdir('po')
 subdir('src')
+
+if get_option('doc')
+  subdir('docs')
+endif
 
 gnome.post_install(
   glib_compile_schemas: true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,22 +10,6 @@ config_file = configure_file(
   configuration: config_data,
 )
 
-granite_dep = dependency('granite-7', version: '>= 7.2.0', required: get_option('granite'))
-if granite_dep.found()
-  add_project_arguments('--define=USE_GRANITE', language: 'vala')
-endif
-
-dependencies = [
-  dependency('gee-0.8'),
-  dependency('gio-unix-2.0'),
-  dependency('glib-2.0', version: '>= 2.74'),
-  granite_dep,
-  dependency('gtk4', version: '>= 4.10'),
-  dependency('libadwaita-1', version: '>= 1.5.0'),
-  dependency('pango'),
-  meson.get_compiler('vala').find_library('posix'),
-]
-
 sources = files(
   'Model/DesktopFile.vala',
   'Model/DesktopFileModel.vala',
@@ -49,34 +33,3 @@ executable(
   dependencies: dependencies,
   install: true,
 )
-
-if get_option('doc')
-  valadoc = find_program('valadoc')
-
-  valadoc_output_dir = 'valadoc'
-  valadoc_target = custom_target(
-    'valadoc',
-    command: [
-      valadoc,
-      '--pkg=gee-0.8',
-      '--pkg=gio-2.0',
-      '--pkg=gio-unix-2.0',
-      '--pkg=glib-2.0',
-      '--pkg=gtk4',
-      '--pkg=libadwaita-1',
-      '--pkg=pango',
-      '--pkg=posix',
-      sources,
-      config_file,
-      '--package-name=' + meson.project_name(),
-      '--package-version=' + meson.project_version(),
-      '--verbose',
-      '--force',
-      '--use-svg-images',
-      '-o', valadoc_output_dir,
-    ],
-
-    build_by_default: true,
-    output: valadoc_output_dir,
-  )
-endif


### PR DESCRIPTION
Bumped required meson version due to the following warning when running `meson setup`

```
WARNING: Project specifies a minimum meson_version '>= 0.58.0' but uses features which were added in newer versions:
 * 1.5.0: {'dependency.name'}
```
